### PR TITLE
:traffic_light: Automerge testing-only deps (fixes noref)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,16 @@
 {
-  "enabled": true
+  "enabled": true,
+  "packages": [
+    {
+      "packagePatterns": [
+        "^babel.*",
+        "^eslint.*",
+        "^karma.*",
+        "^mocha.*",
+        "^nyc.*",
+        "^webpack.*"
+      ],
+      "autoMerge": "minor"
+    }
+  ]
 }


### PR DESCRIPTION
Overview
--------

Reduces PR noise for deps that are only used for testing (and thus CI
checks are sufficient to determine whether to merge)